### PR TITLE
Fix bat环境变量问题, 删除gh action中的extraheader

### DIFF
--- a/.github/workflows/windows_x86-64_pack.yml
+++ b/.github/workflows/windows_x86-64_pack.yml
@@ -45,6 +45,8 @@ jobs:
     - name: Pack windows x86-64 version
       shell: pwsh
       run: |
+        $tmp = Get-Content "HikariBot\.git\config"
+        echo $tmp |Select-String -NotMatch -Pattern "extraheader" | Set-Content "HikariBot\.git\config"
         Compress-Archive -DestinationPath release.zip -Path HikariBot
     - name: Delete latest release
       uses: actions/github-script@v4

--- a/启动.bat
+++ b/启动.bat
@@ -1,6 +1,6 @@
 @echo off
+set PATH=%~dp0pyenv\Library\bin;%~dp0pyenv;%PATH%
 if exist %~dp0\pyenv (
-    set PATH=%~dp0pyenv\Library\bin;%~dp0pyenv
     set PLAYWRIGHT_BROWSERS_PATH=0
 )
 

--- a/更新.bat
+++ b/更新.bat
@@ -1,7 +1,6 @@
 @echo off
-if exist %~dp0\pyenv (
-    set PATH=%~dp0pyenv\Library\bin;%~dp0pyenv;%PATH%
-)
+@rem use pyenv python first
+set PATH=%~dp0pyenv\Library\bin;%~dp0pyenv;%PATH%
 
 echo Try to upgrade the latest hikari-bot
 cd /d %~dp0


### PR DESCRIPTION
Fix bat环境变量问题 解决空格PATH产生的兼容问题
删除gh action中的extraheader，不影响一键包git相关指令